### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/ansg191-lab/arr-backup/compare/v0.1.2...v0.1.3) - 2025-02-15
+
+### Fixed
+
+- *(deps)* update rust crate serde to v1.0.216
+
+### Other
+
+- *(deps)* update ureq to 3.0.5
+- Merge pull request [#58](https://github.com/ansg191-lab/arr-backup/pull/58) from ansg191-lab/renovate/alpine-3.21
+- Merge pull request [#52](https://github.com/ansg191-lab/arr-backup/pull/52) from ansg191-lab/renovate/docker-setup-buildx-action-3.x
+- Merge pull request [#56](https://github.com/ansg191-lab/arr-backup/pull/56) from ansg191-lab/renovate/zip-2.x-lockfile
+- Merge pull request [#59](https://github.com/ansg191-lab/arr-backup/pull/59) from ansg191-lab/renovate/swatinem-rust-cache-digest
+- Merge pull request [#60](https://github.com/ansg191-lab/arr-backup/pull/60) from ansg191-lab/renovate/anyhow-1.x-lockfile
+- add missing `merge_group` to rust tests
+- modify release-plz to use Github App
+- switch to multi-runner docker build
+- remove renovate action
+- Merge pull request [#33](https://github.com/ansg191-lab/arr-backup/pull/33) from ansg191/renovate/rust-1.83.0-alpine
+- *(deps)* update alpine docker tag to v3.21
+
 ## [0.1.2](https://github.com/ansg191/arr-backup/compare/v0.1.1...v0.1.2) - 2024-12-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "arr-backup"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arr-backup"
 description = "Executable to download backups from *arr apps"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 publish = ["anshulg"]


### PR DESCRIPTION



## 🤖 New release

* `arr-backup`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/ansg191-lab/arr-backup/compare/v0.1.2...v0.1.3) - 2025-02-15

### Fixed

- *(deps)* update rust crate serde to v1.0.216

### Other

- *(deps)* update ureq to 3.0.5
- Merge pull request [#58](https://github.com/ansg191-lab/arr-backup/pull/58) from ansg191-lab/renovate/alpine-3.21
- Merge pull request [#52](https://github.com/ansg191-lab/arr-backup/pull/52) from ansg191-lab/renovate/docker-setup-buildx-action-3.x
- Merge pull request [#56](https://github.com/ansg191-lab/arr-backup/pull/56) from ansg191-lab/renovate/zip-2.x-lockfile
- Merge pull request [#59](https://github.com/ansg191-lab/arr-backup/pull/59) from ansg191-lab/renovate/swatinem-rust-cache-digest
- Merge pull request [#60](https://github.com/ansg191-lab/arr-backup/pull/60) from ansg191-lab/renovate/anyhow-1.x-lockfile
- add missing `merge_group` to rust tests
- modify release-plz to use Github App
- switch to multi-runner docker build
- remove renovate action
- Merge pull request [#33](https://github.com/ansg191-lab/arr-backup/pull/33) from ansg191/renovate/rust-1.83.0-alpine
- *(deps)* update alpine docker tag to v3.21
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).